### PR TITLE
Fixes removal of dylibs post codesign causing invalid signature when building from Visual Studio for AppStore

### DIFF
--- a/Xamarin.Swift22.Support.sln
+++ b/Xamarin.Swift22.Support.sln
@@ -1,17 +1,27 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Swift22.Support", "Xamarin.Swift22.Support\Xamarin.Swift22.Support.csproj", "{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		iPhone|Any CPU = iPhone|Any CPU
+		iPhoneSimulator|Any CPU = iPhoneSimulator|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.iPhone|Any CPU.ActiveCfg = iPhone|Any CPU
+		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.iPhone|Any CPU.Build.0 = iPhone|Any CPU
+		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.iPhoneSimulator|Any CPU.ActiveCfg = iPhone|Any CPU
+		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.iPhoneSimulator|Any CPU.Build.0 = iPhone|Any CPU
+		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.Release|Any CPU.ActiveCfg = iPhone|Any CPU
+		{B837D96F-AA4E-4CA4-8767-8E5A1A2C210E}.Release|Any CPU.Build.0 = iPhone|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/Xamarin.Swift22.Support/Xamarin.Swift22.Support.csproj
+++ b/Xamarin.Swift22.Support/Xamarin.Swift22.Support.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -22,9 +22,18 @@
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'iPhone|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>lib\xamarinios10</OutputPath>
+    <OutputPath>lib\xamarinios10\iPhone\</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'iPhoneSimulator|AnyCPU'">
+    <Optimize>true</Optimize>
+    <OutputPath>lib\xamarinios10\iPhoneSimulator\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -44,7 +53,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'iPhone'">
     <Content Include="Frameworks\libswiftContacts.dylib" />
     <Content Include="Frameworks\libswiftCore.dylib" />
     <Content Include="Frameworks\libswiftCoreGraphics.dylib" />
@@ -55,7 +64,7 @@
     <Content Include="Frameworks\libswiftObjectiveC.dylib" />
     <Content Include="Frameworks\libswiftUIKit.dylib" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'iPhoneSimulator'">
     <Content Include="SwiftFrameworksSimulator\libswiftContacts.dylib" />
     <Content Include="SwiftFrameworksSimulator\libswiftCore.dylib" />
     <Content Include="SwiftFrameworksSimulator\libswiftCoreGraphics.dylib" />

--- a/Xamarin.Swift22.Support/build/Xamarin.Swift22.Support.targets
+++ b/Xamarin.Swift22.Support/build/Xamarin.Swift22.Support.targets
@@ -2,7 +2,19 @@
   <UsingTask TaskName="Microsoft.Build.Tasks.Copy" Condition="$(OS) == 'Windows'" AssemblyFile="Xamarin.iOS.Tasks.dll" />
   <UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" Condition="$(OS) == 'Windows'"  AssemblyFile="Xamarin.iOS.Tasks.dll" />
   <UsingTask TaskName="Microsoft.Build.Tasks.Delete" Condition="$(OS) == 'Windows'" AssemblyFile="Xamarin.iOS.Tasks.dll" />
-	
+
+  <Target Name="PlatformCheck" BeforeTargets="InjectReference" Condition="(('$(Platform)' != 'iPhone') AND  ('$(Platform)' != 'iPhoneSimulator'))">
+    <Error  Text="$(MSBuildThisFileName) does not work on '$(Platform)' platform. Specify platform iPhone or iPhoneSimulator." />
+  </Target>
+
+  <Target Name="InjectReference" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup Condition="'$(Platform)' == 'iPhone' or '$(Platform)' == 'iPhoneSimulator'">
+      <Reference Include="Xamarin.Swift22.Support, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+        <HintPath>$(MSBuildThisFileDirectory)..\lib\xamarinios10\$(Platform)\Xamarin.Swift22.Support.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup Condition="'$(Platform)' == 'iPhoneSimulator'">
     <CreateAppBundleDependsOn>
 		$(CreateAppBundleDependsOn);
@@ -11,11 +23,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'iPhone'">
 	<CodesignDependsOn>
-		$(CodesignDependsOn);
-		_RemoveExtraLibs;
-	</CodesignDependsOn>
+    $(CodesignDependsOn);
+    _RemoveExtraLibs;
+  </CodesignDependsOn>
   </PropertyGroup>
-  
+
   <Target Name="_CopySwiftLibsSimulator">
     <ItemGroup>
         <_SwiftLibsSimulator Include="$(_AppBundlePath)SwiftFrameworksSimulator\libswift*.dylib" />
@@ -26,7 +38,7 @@
     <Delete SessionId="$(BuildSessionId)" Files="@(_SwiftLibsDevice)" />
     <Copy SessionId="$(BuildSessionId)" SourceFiles="@(_SwiftLibsSimulator)" DestinationFolder="$(_AppBundlePath)Frameworks" />
   </Target>
-  
+
   <Target Name="_RemoveExtraLibs">
     <RemoveDir SessionId="$(BuildSessionId)" Directories="$(_AppBundlePath)SwiftFrameworksSimulator" />
   </Target>

--- a/Xamarin.Swift22.Support/build/Xamarin.Swift22.Support.targets
+++ b/Xamarin.Swift22.Support/build/Xamarin.Swift22.Support.targets
@@ -1,8 +1,4 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="Microsoft.Build.Tasks.Copy" Condition="$(OS) == 'Windows'" AssemblyFile="Xamarin.iOS.Tasks.dll" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" Condition="$(OS) == 'Windows'"  AssemblyFile="Xamarin.iOS.Tasks.dll" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Delete" Condition="$(OS) == 'Windows'" AssemblyFile="Xamarin.iOS.Tasks.dll" />
-
   <Target Name="PlatformCheck" BeforeTargets="InjectReference" Condition="(('$(Platform)' != 'iPhone') AND  ('$(Platform)' != 'iPhoneSimulator'))">
     <Error  Text="$(MSBuildThisFileName) does not work on '$(Platform)' platform. Specify platform iPhone or iPhoneSimulator." />
   </Target>
@@ -27,19 +23,4 @@
     _RemoveExtraLibs;
   </CodesignDependsOn>
   </PropertyGroup>
-
-  <Target Name="_CopySwiftLibsSimulator">
-    <ItemGroup>
-        <_SwiftLibsSimulator Include="$(_AppBundlePath)SwiftFrameworksSimulator\libswift*.dylib" />
-    </ItemGroup>
-    <ItemGroup>
-        <_SwiftLibsDevice Include="$(_AppBundlePath)Frameworks\libswift*.dylib" />
-    </ItemGroup>
-    <Delete SessionId="$(BuildSessionId)" Files="@(_SwiftLibsDevice)" />
-    <Copy SessionId="$(BuildSessionId)" SourceFiles="@(_SwiftLibsSimulator)" DestinationFolder="$(_AppBundlePath)Frameworks" />
-  </Target>
-
-  <Target Name="_RemoveExtraLibs">
-    <RemoveDir SessionId="$(BuildSessionId)" Directories="$(_AppBundlePath)SwiftFrameworksSimulator" />
-  </Target>
 </Project>

--- a/Xamarin.Swift22.Support/build/Xamarin.Swift22.Support.targets
+++ b/Xamarin.Swift22.Support/build/Xamarin.Swift22.Support.targets
@@ -10,17 +10,4 @@
       </Reference>
     </ItemGroup>
   </Target>
-
-  <PropertyGroup Condition="'$(Platform)' == 'iPhoneSimulator'">
-    <CreateAppBundleDependsOn>
-		$(CreateAppBundleDependsOn);
-      	_CopySwiftLibsSimulator;
-	</CreateAppBundleDependsOn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Platform)' == 'iPhone'">
-	<CodesignDependsOn>
-    $(CodesignDependsOn);
-    _RemoveExtraLibs;
-  </CodesignDependsOn>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
As Xamarin for Visual Studio is missing the 'Sign and Distribute' function in Xamarin Studio, the ipa is not resigned after unneeded dylibs are removed. 

The solution now contains both iPhone and iPhoneSImulator configurations which allows only the dylibs required to be bundled into the dll. Also added a targets file that automatically injects the reference on build based on configuration.
